### PR TITLE
Rakeタスクのリファクタリング

### DIFF
--- a/ops/lib/tasks/test.rake
+++ b/ops/lib/tasks/test.rake
@@ -1,31 +1,30 @@
 namespace :test do
+  work = File.expand_path(File.dirname(__FILE__) + '../../../../dev')
+
   desc 'Rubyテスト'
   task :ruby do
-    cd "dev" do
-      sh "ruby 20181026/FizzBuzzTest.rb"
-      sh "ruby 20181129/k2works/main_test.rb"
-      sh "ruby 20181129/hiroshima_rb/main.rb"
+    cd work do
+      Dir.glob("**/**/*.rb").each do |test|
+        sh "ruby #{test}"
+      end
     end
   end
 
   desc 'Pythonテスト'
   task :python do
-    cd "dev" do
-      sh "python 20181109/main_test.py"
-      sh "python 20181109/replay_main_test.py"
-      sh "python 20181114/k2works/main_test.py"
-      sh "python 20181115/k2works/main_test.py"
-      sh "python 20181116/session/main_test.py"
-      sh "python 20181116/replay/fizz_buzz_test.py"
-      sh "python 20181116/session/main_test.py"
-      sh "python 20181207/session/main_test.py"
+    cd work do
+      Dir.glob("**/**/*.py").each do |test|
+        sh "python #{test}"
+      end
     end
   end
 
   desc 'Elixirテスト'
   task :elixir do
-    cd "dev" do
-      sh "elixir 20181112/FizzBuzzTest.exs"
+    cd work do
+      Dir.glob("**/**/*.exs").each do |test|
+        sh "elixir #{test}"
+      end
     end
   end
 


### PR DESCRIPTION
テストの対象が増えるたびに手動で追加すると追加漏れが発生するので
devディレクトリ以下全てのテスト実行をするようにする。